### PR TITLE
Dockerfile update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,9 +28,9 @@ RUN git clone https://github.com/diasurgical/devilutionx-mpq-tools.git /tmp/devi
     rm -rf /tmp/devilutionx-mpq-tools
 
 # Install d1-graphics-tool
-RUN curl -O -L https://github.com/diasurgical/d1-graphics-tool/releases/latest/download/D1GraphicsTool-Linux-Qt6.deb && \
-    dpkg -i D1GraphicsTool-Linux-Qt6.deb && \
-    rm D1GraphicsTool-Linux-Qt6.deb
+RUN curl -O -L https://github.com/diasurgical/d1-graphics-tool/releases/latest/download/D1GraphicsTool-Linux-Qt5.deb && \
+    dpkg -i D1GraphicsTool-Linux-Qt5.deb && \
+    rm D1GraphicsTool-Linux-Qt5.deb
 
 # Download spawn.mpq and fonts.mpq
 RUN curl --create-dirs -O -L --output-dir /usr/local/share/diasurgical/devilutionx/ \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,9 +28,9 @@ RUN git clone https://github.com/diasurgical/devilutionx-mpq-tools.git /tmp/devi
     rm -rf /tmp/devilutionx-mpq-tools
 
 # Install d1-graphics-tool
-RUN curl -O -L https://github.com/diasurgical/d1-graphics-tool/releases/latest/download/D1GraphicsTool-Linux-x64.deb && \
-    dpkg -i D1GraphicsTool-Linux-x64.deb && \
-    rm D1GraphicsTool-Linux-x64.deb
+RUN curl -O -L https://github.com/diasurgical/d1-graphics-tool/releases/latest/download/D1GraphicsTool-Linux-Qt6.deb && \
+    dpkg -i D1GraphicsTool-Linux-Qt6.deb && \
+    rm D1GraphicsTool-Linux-Qt6.deb
 
 # Download spawn.mpq and fonts.mpq
 RUN curl --create-dirs -O -L --output-dir /usr/local/share/diasurgical/devilutionx/ \


### PR DESCRIPTION
Fixes broken curl reference to outdated release URL for D1GraphicsTool in the Dockerfile

Switched to https://github.com/diasurgical/d1-graphics-tool/releases/latest/download/D1GraphicsTool-Linux-Qt5.deb from https://github.com/diasurgical/d1-graphics-tool/releases/latest/download/D1GraphicsTool-Linux-x64.de

Also fixed the package references in the command line inputs after the curl command