### PR TITLE
Update Dockerfile to fix D1GraphicsTool install step

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,9 +28,9 @@ RUN git clone https://github.com/diasurgical/devilutionx-mpq-tools.git /tmp/devi
     rm -rf /tmp/devilutionx-mpq-tools
 
 # Install d1-graphics-tool
-RUN curl -O -L https://github.com/diasurgical/d1-graphics-tool/releases/latest/download/D1GraphicsTool-Linux-Qt5.deb && \
-    dpkg -i D1GraphicsTool-Linux-Qt5.deb && \
-    rm D1GraphicsTool-Linux-Qt5.deb
+RUN curl -O -L https://github.com/diasurgical/d1-graphics-tool/releases/download/1.1.0/D1GraphicsTool-Linux-x64.deb && \
+    dpkg -i D1GraphicsTool-Linux-x64.deb && \
+    rm D1GraphicsTool-Linux-x64.deb
 
 # Download spawn.mpq and fonts.mpq
 RUN curl --create-dirs -O -L --output-dir /usr/local/share/diasurgical/devilutionx/ \


### PR DESCRIPTION
D1GraphicsTool-Linux-Qt5.deb no longer exists and causes the container setup to fail

This PR fixes the issue by updating the URL called in the curl and subsequent commands to the correct/actual latest version